### PR TITLE
unicode script filenames, see #20

### DIFF
--- a/PythonScript/src/ConfigFile.h
+++ b/PythonScript/src/ConfigFile.h
@@ -1,4 +1,4 @@
-#ifndef _CONFIGFILE_H 
+#ifndef _CONFIGFILE_H
 #define _CONFIGFILE_H
 
 class ConfigFile
@@ -14,13 +14,13 @@ public:
 	static ConfigFile* create(const TCHAR *configDir, const TCHAR *pluginDir, HINSTANCE hInst);
 	static ConfigFile* getInstance()   { return s_instance; };
 
-	
+
 
 	// TODO: Need to make these pointers
 	MenuItemsTD getMenuItems()  { return m_menuItems; };
 	ToolbarItemsTD getToolbarItems()  { return m_toolbarItems; };
-	const std::string& getMenuScript(idx_t index) const;
-	
+	const tstring& getMenuScript(idx_t index) const;
+
 	void addMenuItem(const tstring scriptPath);
 	void addToolbarItem(const tstring scriptPath, const tstring iconPath);
 	void setSetting(const tstring& settingName, const tstring settingValue);
@@ -30,7 +30,7 @@ public:
 	void save();
 
 	void refresh() { clearItems(); readConfig(); };
-	
+
 
 	const tstring& getMachineScriptsDir() { return m_machineScriptsDir; };
 	const tstring& getUserScriptsDir() { return m_userScriptsDir; };
@@ -53,13 +53,13 @@ private:
 	tstring m_configDir;
 
 	MenuItemsTD m_menuItems;
-	std::vector< std::string > m_menuScripts;
-	
+	std::vector< tstring > m_menuScripts;
+
 	// Used in case an invalid script number is requested
 	// so we can return a reference to this puppy instead.
-	std::string m_emptyString;
-	
-	
+	tstring m_emptyString;
+
+
 	ToolbarItemsTD m_toolbarItems;
 	std::map< tstring, HICON > m_icons;
 	SettingsTD m_settings;

--- a/PythonScript/src/MenuManager.h
+++ b/PythonScript/src/MenuManager.h
@@ -26,10 +26,10 @@ public:
 
 	typedef std::vector<std::pair<tstring, void (*)()> > ItemVectorTD;
 	typedef void (*runScriptIDFunc)(idx_t);
-	typedef void(*runScriptFunc)(const char *, bool, HANDLE, bool);
+	typedef void(*runScriptFunc)(const TCHAR *, bool, HANDLE, bool);
 
 	static MenuManager* create(HWND hNotepad, HINSTANCE hInst, runScriptFunc runScript);
-    
+
     /** Destroys the static instance. Must be recreated with create() after usage.
      *  Designed for use in the tests
      */
@@ -64,7 +64,7 @@ public:
 
 	idx_t findMenuCommand(HMENU parentMenu, const TCHAR *parentMenuName, const TCHAR *menuName, const TCHAR *menuOption);
 
-	void updatePreviousScript(const char *filename);
+	void updatePreviousScript(const TCHAR *filename);
 	void updateShortcut(UINT cmdID, ShortcutKey* key);
 	void initPreviousScript();
 
@@ -73,15 +73,15 @@ public:
 	bool inDynamicRange(idx_t commandID);
 	bool inToolbarRange(idx_t commandID);
 	bool inFixedRange(idx_t commandID);
-	
+
 
 	BOOL processWmCommand(WPARAM wParam, LPARAM lParam);
 	idx_t getOriginalCommandID(idx_t scriptNumber);
 
 	static bool s_menuItemClicked;
 	static WNDPROC s_origWndProc;
-	
-	
+
+
 
 private:
 	MenuManager(); // default constructor disabled
@@ -89,19 +89,19 @@ private:
 	MenuManager(HWND hNotepad, HINSTANCE hInst, runScriptFunc runScript);
 
 	HMENU getOurMenu();
-	bool findScripts(HMENU hBaseMenu, size_t basePathLength, std::string& path);
+	bool findScripts(HMENU hBaseMenu, size_t basePathLength, tstring& path);
 	void subclassNotepadPlusPlus();
-	
+
 
 	tstring formatMenuName(const TCHAR *name);
 
-	
+
 
 	runScriptFunc m_runScript;
 
-	typedef std::set<std::string> MachineScriptNamesTD;
-	typedef std::map<idx_t, std::string> ScriptCommandsTD;
-	typedef std::map<std::string, HMENU> SubmenusTD;
+	typedef std::set<tstring> MachineScriptNamesTD;
+	typedef std::map<idx_t, tstring> ScriptCommandsTD;
+	typedef std::map<tstring, HMENU> SubmenusTD;
 	typedef std::map<std::pair<tstring, tstring>, idx_t> MenuCommandCacheTD;
 	MenuCommandCacheTD m_menuCommandCache;
 	MenuCommandCacheTD m_pluginCommandCache;
@@ -130,12 +130,12 @@ private:
 	idx_t		m_originalLastCmdIndex;
 	HMENU		m_pythonPluginMenu;
 	HMENU		m_hScriptsMenu;
-	FuncItem*   m_funcItems;
+	FuncItem*	m_funcItems;
 	size_t		m_funcItemCount;
-	std::string m_machineScriptsPath;
-	std::string m_userScriptsPath;
+	tstring		m_machineScriptsPath;
+	tstring		m_userScriptsPath;
 	tstring		m_runLastScriptShortcut;
-	std::string m_previousRunFilename;
+	tstring		m_previousRunFilename;
 
 	IDAllocator* m_idAllocator;
 	DynamicIDManager* m_dynamicMenuManager;
@@ -200,7 +200,7 @@ private:
 
 	void (*m_runScriptFuncs[MAX_MENU_SCRIPTS])(void);
 
-	
+
 };
 
 #endif // _MENUMANAGER_H

--- a/PythonScript/src/PythonHandler.h
+++ b/PythonScript/src/PythonHandler.h
@@ -20,13 +20,13 @@ struct RunScriptArgs
 {
 public:
 	RunScriptArgs(
-		const char* filename,
+		const TCHAR* filename,
 		PyThreadState *threadState,
 		bool synchronous,
 		HANDLE completedEvent,
 		bool isStatement
 	):
-		m_filename(filename?filename:""),
+		m_filename(filename?filename:_T("")),
 		m_threadState(threadState),
 		m_synchronous(synchronous),
 		m_completedEvent(completedEvent),
@@ -35,7 +35,7 @@ public:
 
 	}
 
-	std::string m_filename;
+	tstring m_filename;
 	PyThreadState *m_threadState;
 	bool m_synchronous;
 	HANDLE m_completedEvent;
@@ -52,9 +52,9 @@ public:
 	PythonHandler::PythonHandler(TCHAR *pluginsDir, TCHAR *configDir, HINSTANCE hInst, HWND nppHandle, HWND scintilla1Handle, HWND scintilla2Handle, boost::shared_ptr<PythonConsole> pythonConsole);
 	~PythonHandler();
 
-	bool runScript(const char *filename, bool synchronous = false, bool allowQueuing = false, HANDLE completedEvent = NULL, bool isStatement = false);
-	bool runScript(const std::string& filename, bool synchronous = false, bool allowQueuing = false, HANDLE completedEvent = NULL, bool isStatement = false);
-	
+	bool runScript(const TCHAR *filename, bool synchronous = false, bool allowQueuing = false, HANDLE completedEvent = NULL, bool isStatement = false);
+	bool runScript(const tstring& filename, bool synchronous = false, bool allowQueuing = false, HANDLE completedEvent = NULL, bool isStatement = false);
+
 	void runScriptWorker(const std::shared_ptr<RunScriptArgs>& args);
 
 	void notify(SCNotification *notifyCode);
@@ -66,7 +66,7 @@ public:
 	PyThreadState* getMainThreadState() { return mp_mainThreadState; };
 
 	DWORD getExecutingThreadID() { return getConsumerThreadID(); };
-	
+
 
 protected:
 	void consume(std::shared_ptr<RunScriptArgs> args);
@@ -79,13 +79,13 @@ protected:
 	HWND m_nppHandle;
 	HWND m_scintilla1Handle;
 	HWND m_scintilla2Handle;
-	
+
 
 
 private:
-	PythonHandler(); // default constructor disabled
-	PythonHandler(const PythonHandler&); // copy constructor disabled
-	PythonHandler& operator = (const PythonHandler&); // Disable assignment operator disabled
+	PythonHandler() = delete; // default constructor disabled
+	PythonHandler(const PythonHandler&) = delete; // copy constructor disabled
+	PythonHandler& operator = (const PythonHandler&) = delete; // Disable assignment operator disabled
 
 	// Private methods
 	void initModules();

--- a/PythonScript/src/ScintillaWrapper.h
+++ b/PythonScript/src/ScintillaWrapper.h
@@ -68,7 +68,7 @@ public:
 	void clearCallbackEvents(boost::python::list events);
 	void clearCallback(PyObject* callback, boost::python::list events);
 
-	/* Helper functions 
+	/* Helper functions
 	 * These functions are designed to make life easier for scripting,
 	 * but don't perform any "magic"
 	 */
@@ -79,8 +79,8 @@ public:
 	boost::python::tuple getUserLineSelection();
 	boost::python::tuple getUserCharSelection();
 	void setTarget(int start, int end);
-	
-    /** Returns the flag to be combined with the re flag constants, in order to set the 
+
+    /** Returns the flag to be combined with the re flag constants, in order to set the
      *  re anchors to treat the document as a whole, a not per line. ie. ^ matches the start of the document,
      *  and $ matches the end.  Default is ^ matches start of line, $ the end.
      */
@@ -98,7 +98,7 @@ public:
     void replaceRegexFlagsStartEndMaxCount(boost::python::object searchStr, boost::python::object replaceStr, int flags, int start, int end, int maxCount);
 
 	void replaceImpl(boost::python::object searchStr, boost::python::object replaceStr, int count, python_re_flags flags, int startPosition, int endPosition);
-	
+
     void searchPlain(boost::python::object searchStr, boost::python::object matchFunction);
     void searchPlainFlags(boost::python::object searchStr, boost::python::object matchFunction, int flags);
     void searchPlainFlagsStart(boost::python::object searchStr, boost::python::object matchFunction, int flags, int startPosition);
@@ -127,7 +127,7 @@ public:
 	void pyreplaceNoEnd(boost::python::object searchExp, boost::python::object replaceStr, boost::python::object count, boost::python::object flags, boost::python::object startLine)
 					{	pyreplace(searchExp, replaceStr, count, flags, startLine, boost::python::object()); };
 
-	
+
 	void pymlreplace(boost::python::object searchExp, boost::python::object replaceStr, boost::python::object count, boost::python::object flags, boost::python::object startPosition, boost::python::object endPosition);
 	void pymlreplaceNoFlagsNoCount(boost::python::object searchExp, boost::python::object replaceStr)
 					{	pymlreplace(searchExp, replaceStr, boost::python::object(0), boost::python::object(0), boost::python::object(), boost::python::object()); };
@@ -160,20 +160,20 @@ public:
 					{ return getWord(position, boost::python::object(true)); };
 	boost::python::str getCurrentWord()
 					{ return getWord(boost::python::object(), boost::python::object(true)); };
-	
+
 	// This "normal" Scintilla function has been implemented manually, as it returns a pointer, which we can convert to a string
 	boost::python::str GetCharacterPointer();
 
 	// This "normal" Scintilla function has been implemented manually, as it returns a pointer, which we can convert to a string
     boost::python::str GetRangePointer(int position, int length);
 
-    /** This helper function gets a std::string from the given object. 
+    /** This helper function gets a std::string from the given object.
       * If the object is a unicode string, it converts the string to UTF-8.
       * If it's an object, it calls the __str__ method to convert the object to a string
       */
     std::string getStringFromObject(boost::python::object o);
 
-    /**  Flash the editor by reversing foreground and background colours 
+    /**  Flash the editor by reversing foreground and background colours
      */
     void flash() { flashMilliseconds(50); }
     void flashMilliseconds(int milliseconds);
@@ -3023,28 +3023,28 @@ public:
         GILRelease release;
 		return SendMessage(m_handle, message, wParam, lParam);
 	}
-    
-	
+
+
 protected:
 	void consume(std::shared_ptr<CallbackExecArgs> args);
 
-	
+
 private:
-	ScintillaWrapper(); // default constructor disabled
-    ScintillaWrapper(const ScintillaWrapper& copy);  // copy constructor disabled
-    ScintillaWrapper& operator = (const ScintillaWrapper& rhs);  // assignment operator disabled
+	ScintillaWrapper() = delete; // default constructor disabled
+    ScintillaWrapper(const ScintillaWrapper& copy) = delete;  // copy constructor disabled
+    ScintillaWrapper& operator = (const ScintillaWrapper& rhs) = delete;  // assignment operator disabled
 	// Active Scintilla handle
 	HWND m_handle;
 
     // Notepad++ handle (used for replace)
     HWND m_hNotepad;
-	
+
 	// Callbacks
 	HANDLE m_callbackMutex;
 	callbackT m_callbacks;
-	
+
 	bool m_notificationsEnabled;
-	
+
 	static void runCallbacks(CallbackExecArgs *args);
 
     void runCallbacks(std::shared_ptr<CallbackExecArgs> args);
@@ -3055,8 +3055,8 @@ private:
     boost::python::object m_pythonMatchHandler;
 
     const char *getCurrentAnsiCodePageName();
-    
-	// If the current thread is the main UI thread and a callback is currently in progress, 
+
+	// If the current thread is the main UI thread and a callback is currently in progress,
 	// then this call throws an exception
 	void notAllowedInCallback(const char *message);
 

--- a/PythonScript/src/ShortcutDlg.cpp
+++ b/PythonScript/src/ShortcutDlg.cpp
@@ -27,12 +27,12 @@ ShortcutDlg::ShortcutDlg(HINSTANCE hInst, NppData& nppData, const TCHAR *scriptD
 	Window::init(hInst, nppData._nppHandle);
 	TCHAR temp[MAX_PATH];
 	::SendMessage(nppData._nppHandle, NPPM_GETPLUGINSCONFIGDIR, MAX_PATH, reinterpret_cast<LPARAM>(temp));
-		
+
 	m_userScriptDir = temp;
 	m_userScriptDir.append(scriptDirAppend);
 
 	::SendMessage(nppData._nppHandle, NPPM_GETNPPDIRECTORY, MAX_PATH, reinterpret_cast<LPARAM>(temp));
-	
+
 	m_machineScriptDir = temp;
 	m_machineScriptDir.append(_T("\\plugins"));
 	m_machineScriptDir.append(scriptDirAppend);
@@ -141,7 +141,7 @@ INT_PTR CALLBACK ShortcutDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 									// a non-NULL lParam means it's a python file (with a full path)
 									if (lptvdi->item.lParam)
 										imageIndex = m_iconPython;
-									else 
+									else
 										imageIndex = m_iconFolderClosed;
 								}
 
@@ -181,12 +181,12 @@ INT_PTR CALLBACK ShortcutDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 					} // end switch (hdr->code)
 
 				}  // end case IDC_FILETREE
-				break;  
+				break;
 
 				default:
 					// Other windows we can ignore
 					break;
-			} // end switch hdr->idFrom 
+			} // end switch hdr->idFrom
 		} // end case WM_NOTIFY
 		break;
 
@@ -209,34 +209,34 @@ void ShortcutDlg::onInitDialog()
 	m_hListToolbarItems = ::GetDlgItem(_hSelf, IDC_TOOLBARITEMLIST2);
 	m_hComboInitialisation = ::GetDlgItem(_hSelf, IDC_COMBOINITIALISATION);
 	InitCommonControls();
-	HICON hIcon;           // handle to icon 
- 
-	// Create a masked image list large enough to hold the icons. 
-	m_hIcons = ImageList_Create(16, 16, ILC_MASK | ILC_COLOR32, 3, 0); 
- 
-	// Load the icon resources, and add the icons to the image list. 
-	hIcon = LoadIcon(_hInst, MAKEINTRESOURCE(IDI_FOLDERCLOSED)); 
-	m_iconFolderClosed = ImageList_AddIcon(m_hIcons, hIcon); 
- 
-	hIcon = LoadIcon(_hInst, MAKEINTRESOURCE(IDI_FOLDEROPEN)); 
-	m_iconFolderOpen = ImageList_AddIcon(m_hIcons, hIcon); 
+	HICON hIcon;           // handle to icon
 
-	hIcon = LoadIcon(_hInst, MAKEINTRESOURCE(IDI_PYTHON)); 
-	m_iconPython = ImageList_AddIcon(m_hIcons, hIcon); 
+	// Create a masked image list large enough to hold the icons.
+	m_hIcons = ImageList_Create(16, 16, ILC_MASK | ILC_COLOR32, 3, 0);
+
+	// Load the icon resources, and add the icons to the image list.
+	hIcon = LoadIcon(_hInst, MAKEINTRESOURCE(IDI_FOLDERCLOSED));
+	m_iconFolderClosed = ImageList_AddIcon(m_hIcons, hIcon);
+
+	hIcon = LoadIcon(_hInst, MAKEINTRESOURCE(IDI_FOLDEROPEN));
+	m_iconFolderOpen = ImageList_AddIcon(m_hIcons, hIcon);
+
+	hIcon = LoadIcon(_hInst, MAKEINTRESOURCE(IDI_PYTHON));
+	m_iconPython = ImageList_AddIcon(m_hIcons, hIcon);
 
 	::SendMessage(m_hTree, TVM_SETIMAGELIST, TVSIL_NORMAL, reinterpret_cast<LPARAM>(m_hIcons));
 	::SendMessage(m_hTree, TVM_SETIMAGELIST, TVSIL_STATE, reinterpret_cast<LPARAM>(m_hIcons));
 	m_hImageList = ImageList_Create(16, 16, ILC_MASK |ILC_COLOR32, 5, 1);
 	HBITMAP hPython = static_cast<HBITMAP>(LoadImage(_hInst, MAKEINTRESOURCE(IDB_PYTHON), IMAGE_BITMAP, 0, 0, LR_COLOR | LR_LOADMAP3DCOLORS | LR_DEFAULTSIZE));
 	m_hDefaultImageIndex = ImageList_Add(m_hImageList, hPython, NULL);
-	ListView_SetImageList(m_hListToolbarItems, m_hImageList, LVSIL_SMALL); 
+	ListView_SetImageList(m_hListToolbarItems, m_hImageList, LVSIL_SMALL);
 	LVCOLUMN lvCol;
 	lvCol.cchTextMax = 10;
 	lvCol.mask = LVCF_FMT | LVCF_WIDTH | LVCF_TEXT;
 	lvCol.iSubItem = 0;
 	lvCol.pszText = _T("Script");
 	lvCol.fmt = LVCFMT_LEFT;
-	
+
 	RECT rect;
 	::GetClientRect(m_hListToolbarItems, &rect);
 	m_toolbarColumnWidth = (size_t)((rect.right - rect.left) - 18);
@@ -289,19 +289,19 @@ void ShortcutDlg::populateScripts(tstring dir, HTREEITEM parent /* = TVI_ROOT */
 	while (found)
 	{
 		if (FILE_ATTRIBUTE_DIRECTORY == (findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
-			&& _tcscmp(findData.cFileName, _T(".")) 
+			&& _tcscmp(findData.cFileName, _T("."))
 			&& _tcscmp(findData.cFileName, _T("..")))
 		{
 			searchPath = dir;
 			searchPath.append(_T("\\"));
 			searchPath.append(findData.cFileName);
-			
-			
+
+
 			lastItem = addTreeItem(parent, lastItem, NULL, findData.cFileName, true);
-			
-			
+
+
 			populateScripts(searchPath, lastItem);
-			
+
 		}
 
 		found = FindNextFile(hFound, &findData);
@@ -314,29 +314,29 @@ void ShortcutDlg::populateScripts(tstring dir, HTREEITEM parent /* = TVI_ROOT */
 	searchPath.append(_T("\\*.py"));
 	hFound = FindFirstFile(searchPath.c_str(), &findData);
 	found = (hFound != INVALID_HANDLE_VALUE) ? TRUE : FALSE;
-	
-	
+
+
 	while(found)
 	{
 		tstring fullFilename(dir);
 		fullFilename.append(_T("\\"));
 		fullFilename.append(findData.cFileName);
-		
+
 		size_t length = fullFilename.size() + 1;
 		std::shared_ptr<TCHAR> item(new TCHAR[length]);
-		
+
 		_tcscpy_s(item.get(), length, fullFilename.c_str());
 
 		m_itemList.push_back(item);
 
 		lastItem = addTreeItem(parent, lastItem, item.get(), findData.cFileName, false);
-		
-		
+
+
 		found = FindNextFile(hFound, &findData);
 	}
 
 	FindClose(hFound);
-	
+
 }
 
 
@@ -346,7 +346,7 @@ void ShortcutDlg::populateScripts(tstring dir, HTREEITEM parent /* = TVI_ROOT */
 HTREEITEM ShortcutDlg::addTreeItem(HTREEITEM parent, HTREEITEM /* lastItem */, TCHAR *fullPath, TCHAR *text, bool isDirectory)
 {
 	TV_INSERTSTRUCT tvInsert;
-	tvInsert.hParent = parent; 
+	tvInsert.hParent = parent;
 	tvInsert.hInsertAfter = TVI_SORT;
 	tvInsert.item.mask = TVIF_TEXT | TVIF_PARAM |TVIF_IMAGE | TVIF_SELECTEDIMAGE;
 	tvInsert.item.lParam = reinterpret_cast<LPARAM>(fullPath);
@@ -387,10 +387,10 @@ void ShortcutDlg::addMenuItem(const TCHAR *item)
 	lvItem.iSubItem = 0;
 	lvItem.state = 0;
 	lvItem.stateMask = 0;
-	
+
 	TCHAR path[MAX_PATH];
 	_tcscpy_s(path, MAX_PATH, item);
-	::PathCompactPath(NULL, path, m_menuItemColumnWidth);
+	::PathCompactPath(NULL, path, static_cast<UINT>(m_menuItemColumnWidth));
 
 	lvItem.pszText = path;
 	lvItem.cchTextMax = (int)_tcslen(path);
@@ -400,7 +400,7 @@ void ShortcutDlg::addMenuItem(const TCHAR *item)
 void ShortcutDlg::removeMenuItem()
 {
 	int index = ListView_GetNextItem(m_hListMenuItems, -1, LVIS_SELECTED);
-	
+
 	if (index != -1)
 	{
 		ListView_DeleteItem(m_hListMenuItems, index);
@@ -437,10 +437,10 @@ void ShortcutDlg::addToolbarItem(const TCHAR *item, HBITMAP hBitmap)
 	lvItem.state = 0;
 	lvItem.stateMask = 0;
 	lvItem.iImage = imageIndex;
-	
+
 	TCHAR path[MAX_PATH];
 	_tcscpy_s(path, MAX_PATH, item);
-	::PathCompactPath(NULL, path, m_toolbarColumnWidth);
+	::PathCompactPath(NULL, path, static_cast<UINT>(m_toolbarColumnWidth));
 
 	lvItem.pszText = path;
 	lvItem.cchTextMax = (int)_tcslen(path);
@@ -458,9 +458,9 @@ void ShortcutDlg::addToolbarItem(const TCHAR *item, HBITMAP hBitmap)
 
 void ShortcutDlg::removeToolbarItem()
 {
-	
+
 	int index = ListView_GetNextItem(m_hListToolbarItems, -1, LVIS_SELECTED);
-	
+
 	if (index != -1)
 	{
 		ListView_DeleteItem(m_hListToolbarItems, index);
@@ -515,21 +515,21 @@ void ShortcutDlg::saveConfig()
 	configFile->clearItems();
 
 	for (ConfigFile::MenuItemsTD::iterator it = m_menuItems.begin(); it != m_menuItems.end(); ++it)
-	{	
+	{
 		configFile->addMenuItem(*it);
 	}
 
-	
+
 
 	for (ConfigFile::ToolbarItemsTD::iterator it = m_toolbarItems.begin(); it != m_toolbarItems.end(); ++it)
-	{	
+	{
 		configFile->addToolbarItem(it->first, it->second.second);
 	}
 
 	TCHAR startupBuffer[50];
 	ComboBox_GetText(m_hComboInitialisation, startupBuffer, 50);
 	configFile->setSetting(_T("STARTUP"), startupBuffer);
-    
+
 	if (BST_CHECKED == IsDlgButtonChecked(_hSelf, IDC_CHECKPREFERINSTALLEDPYTHON)) {
         configFile->setSetting(_T("PREFERINSTALLEDPYTHON"), _T("1"));
 	} else {
@@ -543,7 +543,7 @@ void ShortcutDlg::saveConfig()
 void ShortcutDlg::toolbarSetIcon()
 {
 	int index = ListView_GetNextItem(m_hListToolbarItems, -1, LVIS_SELECTED);
-	
+
 	if (index != -1)
 	{
 		OPENFILENAME ofn;
@@ -551,7 +551,7 @@ void ShortcutDlg::toolbarSetIcon()
 
 		ofn.lStructSize = sizeof(OPENFILENAME);
 		ofn.hwndOwner = _hSelf;
-	
+
 		tstring configDir(ConfigFile::getInstance()->getConfigDir());
 		configDir.append(_T("\\PythonScript\\icons"));
 		ofn.lpstrInitialDir = configDir.c_str();
@@ -566,7 +566,7 @@ void ShortcutDlg::toolbarSetIcon()
 		ofn.nFilterIndex = 1;
 
 		ofn.Flags = OFN_FILEMUSTEXIST;
-	
+
 
 		if (GetOpenFileName(&ofn))
 		{

--- a/PythonScript/src/WcharMbcsConverter.cpp
+++ b/PythonScript/src/WcharMbcsConverter.cpp
@@ -24,12 +24,12 @@ Modified for inclusion in VS2010 project "Python Script"
 
 std::shared_ptr<wchar_t> WcharMbcsConverter::char2wchar(const char* mbStr)
 {
-	
+
 	std::shared_ptr<wchar_t> wideCharStr;
 
 	size_t len = (size_t)MultiByteToWideChar(CP_UTF8, 0, mbStr, -1, NULL, 0);
-	
-	
+
+
 	if (len > 0)
 	{
 		wideCharStr.reset(new wchar_t[len]);
@@ -92,4 +92,10 @@ std::shared_ptr<char> WcharMbcsConverter::tchar2char(const TCHAR* tStr)
 #endif
 }
 
-
+std::shared_ptr<TCHAR> WcharMbcsConverter::tchar2tchar(const TCHAR* tStr)
+{
+	size_t len = _tcslen(tStr) + 1;
+	std::shared_ptr<TCHAR> result(new TCHAR[len]);
+	_tcscpy_s(result.get(), len, tStr);
+	return result;
+}

--- a/PythonScript/src/WcharMbcsConverter.h
+++ b/PythonScript/src/WcharMbcsConverter.h
@@ -24,13 +24,14 @@ Modified for inclusion in VS2010 project "Python Script"
 
 class WcharMbcsConverter {
 public:
-	
+
 	static std::shared_ptr<wchar_t> char2wchar(const char* mbStr);
 	static std::shared_ptr<char>    wchar2char(const wchar_t* wcStr);
 
 	static std::shared_ptr<TCHAR>   char2tchar(const char* mbStr);
 	static std::shared_ptr<char>    tchar2char(const TCHAR* tStr);
 
+	static std::shared_ptr<TCHAR> tchar2tchar(const TCHAR * tStr);
 
 };
 


### PR DESCRIPTION
- adapt for unicode filenames to be displayed in menu list
- removed trailing whitespaces
- added workaround to load unicode scripts via the short name
- used char(UTF8) to store config file on disk, due to issue with TCHAR, see https://www.codeproject.com/Articles/38242/Reading-UTF-with-C-streams