### PR TITLE
adapt deliveries structure

### DIFF
--- a/PythonScript/src/HelpController.cpp
+++ b/PythonScript/src/HelpController.cpp
@@ -47,7 +47,7 @@ std::wstring HelpController::getFilename()
 {
 	TCHAR helpPath[MAX_PATH];
 	::SendMessage(m_hNotepad, NPPM_GETNPPDIRECTORY, MAX_PATH, reinterpret_cast<LPARAM>(helpPath));
-	_tcscat_s(helpPath, MAX_PATH, _T("\\plugins\\doc\\PythonScript"));
+	_tcscat_s(helpPath, MAX_PATH, _T("\\plugins\\PythonScript\\doc\\PythonScript"));
 
 	if (::PathFileExists(helpPath))
 	{

--- a/installer/PythonScript.wxs
+++ b/installer/PythonScript.wxs
@@ -2,13 +2,23 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
 	
 
-	<Product Id="*" Language="1033" Manufacturer="Dave Brotherstone" Name="PythonScript plugin for Notepad++"
+	<?if $(var.Platform) = x64 ?>
+		<?define ProductName = "PythonScript plugin for Notepad++ (64 bit)" ?>
+		<?define Win64 = "yes" ?>
+		<?define PlatformProgramFilesFolder = "ProgramFiles64Folder" ?>
+	<?else ?>
+		<?define ProductName = "PythonScript plugin for Notepad++" ?>
+		<?define Win64 = "no" ?>
+		<?define PlatformProgramFilesFolder = "ProgramFilesFolder" ?>
+	<?endif ?>
+
+	<Product Id="*" Language="1033" Manufacturer="Dave Brotherstone" Name="$(var.ProductName)"
 			UpgradeCode="717FEC91-6F2B-459D-9868-0A3A037F5195" 
 			Version="$(var.version)">
 		
 		
 
-		<Package Id='*' InstallerVersion='200' Compressed='yes' />  
+		<Package Id='*' InstallerVersion='200' Platform="$(var.Platform)" Compressed='yes' />  
 		
 		<Upgrade Id="717FEC91-6F2B-459D-9868-0A3A037F5195">  
 		   <UpgradeVersion Minimum="0.0.0.0" Maximum="$(var.version)"
@@ -24,13 +34,13 @@
 
 		<Property Id="INSTALLLEVEL" Value="5" />
 		<Directory Id="TARGETDIR" Name="SourceDir">
-			<Directory Id="ProgramFilesFolder">
+			<Directory Id="$(var.PlatformProgramFilesFolder)">
 				<Directory Id="INSTALLDIR" Name="Notepad++">
 					<Directory Id="D_Plugins" Name="plugins">
 						<Directory Id="D_PythonScript" Name="PythonScript">
 							<Directory Id="D_PythonLib" Name="lib" />
 							<Directory Id="D_Scripts" Name="scripts">
-								<Component Id="C_startup.py" Guid="*">
+								<Component Id="C_startup.py" Guid="*" Win64="$(var.Win64)">
 									<RemoveFile Id="Remove_F_startup.py" Name="startup.py" On="install"/>
 									<RemoveFile Id="Remove_F_startup.pyc" Name="startup.pyc" On="install"/>
 									<File Id="F_startup.py" KeyPath="yes" Name="startup.py" Source="$(var.baseDir)\scripts\startup.py" />
@@ -38,19 +48,19 @@
 								<Directory Id="D_npp_unit_tests" Name="npp_unit_tests" />
 								<Directory Id="D_SampleScripts" Name="Samples" />
 							</Directory>
+							<Directory Id="D_doc" Name="doc">
+								<Directory Id="D_DocPythonScript" Name="PythonScript" />
+							</Directory>
+							<Component Id="C_pythonscript.dll" Guid="*" Win64="$(var.Win64)">
+								<RemoveFile Id="Remove_F_pythonscript.dll" Name="PythonScript.dll" On="install"/>
+								<File Id="F_pythonscript.dll" Name="PythonScript.dll" Source="$(var.baseDir)\$(var.variantDir)\Release\PythonScript.dll" />
+							</Component>
+							<Component Id="C_python27.dll" Guid="*" Win64="$(var.Win64)">
+								<RemoveFile Id="Remove_F_python27.dll" Name="python27.dll" On="install"/>
+								<File Id="F_python27.dll" Name="python27.dll" Source="$(var.pythonDir)\python27.dll" />
+							</Component>
 						</Directory>
-						<Directory Id="D_doc" Name="doc">
-							<Directory Id="D_DocPythonScript" Name="PythonScript" />
-						</Directory>
-						<Component Id="C_pythonscript.dll" Guid="*">
-							<RemoveFile Id="Remove_F_pythonscript.dll" Name="PythonScript.dll" On="install"/>
-							<File Id="F_pythonscript.dll" Name="PythonScript.dll" Source="$(var.baseDir)\$(var.variantDir)\Release\PythonScript.dll" />
-						</Component>
 					</Directory>
-					<Component Id="C_python27.dll" Guid="*">
-						<RemoveFile Id="Remove_F_python27.dll" Name="python27.dll" On="install"/>
-						<File Id="F_python27.dll" Name="python27.dll" Source="$(var.pythonDir)\python27.dll" />
-					</Component>
 				</Directory>
 			</Directory>
 		</Directory>

--- a/installer/buildInstaller.bat
+++ b/installer/buildInstaller.bat
@@ -16,7 +16,8 @@ IF NOT EXIST "buildPaths.bat" (
 
 SET PYTHONSCRIPTDLLDIR=bin
 SET INST_TEMP_DIR=temp
-SET NAME_ADDON=""
+SET NAME_ADDON=
+SET MSI_ARCH=x86
 
 CALL buildPaths.bat
 
@@ -24,6 +25,7 @@ IF "%1"=="x64" SET PYTHONBUILDDIR=%PYTHONBUILDDIR_X64%
 IF "%1"=="x64" SET PYTHONSCRIPTDLLDIR=x64
 IF "%1"=="x64" SET INST_TEMP_DIR=temp64
 IF "%1"=="x64" SET NAME_ADDON=_x64
+IF "%1"=="x64" SET MSI_ARCH=x64
 
 IF NOT EXIST "%PYTHONBUILDDIR%\python.exe" (
 	echo Your PYTHONBUILDDIR in buildPaths.bat does not contain python.exe.  Please set PYTHONBUILDDIR to the root of a built Python 2.7
@@ -48,7 +50,7 @@ if NOT [%ERRORLEVEL%]==[0] (
 )
 
 echo Compiling python lib WiX source
-candle %INST_TEMP_DIR%\fullLib.wxs -o %INST_TEMP_DIR%\fullLib.wixobj -dpylibSource=..\pythonlib\full
+candle %INST_TEMP_DIR%\fullLib.wxs -o %INST_TEMP_DIR%\fullLib.wixobj -dpylibSource=..\pythonlib\full -arch %MSI_ARCH%
 if NOT [%ERRORLEVEL%]==[0] (
  goto error
 )
@@ -60,7 +62,7 @@ if NOT [%ERRORLEVEL%]==[0] (
 )
 
 echo Compiling python pyd lib WiX source
-candle %INST_TEMP_DIR%\fullLib_dll%NAME_ADDON%.wxs -o %INST_TEMP_DIR%\fullLib_dll%NAME_ADDON%.wixobj -dpylibSource=..\pythonlib\full_dll%NAME_ADDON%
+candle %INST_TEMP_DIR%\fullLib_dll%NAME_ADDON%.wxs -o %INST_TEMP_DIR%\fullLib_dll%NAME_ADDON%.wixobj -dpylibSource=..\pythonlib\full_dll%NAME_ADDON% -arch %MSI_ARCH%
 if NOT [%ERRORLEVEL%]==[0] (
  goto error
 )
@@ -72,7 +74,7 @@ if NOT [%ERRORLEVEL%]==[0] (
 )
 
 echo Compiling extra lib WiX source
-candle %INST_TEMP_DIR%\extra.wxs -o %INST_TEMP_DIR%\extra.wixobj -dpylibSource=..\pythonlib\extra
+candle %INST_TEMP_DIR%\extra.wxs -o %INST_TEMP_DIR%\extra.wixobj -dpylibSource=..\pythonlib\extra -arch %MSI_ARCH%
 if NOT [%ERRORLEVEL%]==[0] (
  goto error
 )
@@ -84,7 +86,7 @@ if NOT [%ERRORLEVEL%]==[0] (
 )
 
 echo Compiling extra lib WiX source
-candle %INST_TEMP_DIR%\extra_dll%NAME_ADDON%.wxs -o %INST_TEMP_DIR%\extra_dll%NAME_ADDON%.wixobj -dpylibSource=..\pythonlib\extra_dll%NAME_ADDON%
+candle %INST_TEMP_DIR%\extra_dll%NAME_ADDON%.wxs -o %INST_TEMP_DIR%\extra_dll%NAME_ADDON%.wixobj -dpylibSource=..\pythonlib\extra_dll%NAME_ADDON% -arch %MSI_ARCH%
 if NOT [%ERRORLEVEL%]==[0] (
  goto error
 )
@@ -96,7 +98,7 @@ if NOT [%ERRORLEVEL%]==[0] (
 )
 
 echo Compiling tcl lib WiX source
-candle %INST_TEMP_DIR%\tcl.wxs -o %INST_TEMP_DIR%\tcl.wixobj -dpylibSource=..\pythonlib\tcl
+candle %INST_TEMP_DIR%\tcl.wxs -o %INST_TEMP_DIR%\tcl.wixobj -dpylibSource=..\pythonlib\tcl -arch %MSI_ARCH%
 if NOT [%ERRORLEVEL%]==[0] (
  goto error
 )
@@ -108,7 +110,7 @@ if NOT [%ERRORLEVEL%]==[0] (
 )
 
 echo Compiling tcl lib WiX source
-candle %INST_TEMP_DIR%\tcl_dll%NAME_ADDON%.wxs -o %INST_TEMP_DIR%\tcl_dll%NAME_ADDON%.wixobj -dpylibSource=..\pythonlib\tcl_dll%NAME_ADDON%
+candle %INST_TEMP_DIR%\tcl_dll%NAME_ADDON%.wxs -o %INST_TEMP_DIR%\tcl_dll%NAME_ADDON%.wixobj -dpylibSource=..\pythonlib\tcl_dll%NAME_ADDON% -arch %MSI_ARCH%
 if NOT [%ERRORLEVEL%]==[0] (
  goto error
 )
@@ -120,38 +122,38 @@ if NOT [%ERRORLEVEL%]==[0] (
 )
 
 echo Compiling Sample Scripts WiX source
-candle %INST_TEMP_DIR%\sampleScripts.wxs -o %INST_TEMP_DIR%\sampleScripts.wixobj -dscriptSource=..\scripts\Samples
+candle %INST_TEMP_DIR%\sampleScripts.wxs -o %INST_TEMP_DIR%\sampleScripts.wixobj -dscriptSource=..\scripts\Samples -arch %MSI_ARCH%
 if NOT [%ERRORLEVEL%]==[0] (
  goto error
 )
 
 
 echo Generating WiX information for ..\PythonScript\python_tests
-heat dir ..\PythonScript\python_tests -ag -cg CG_UnitTests -dr D_PythonScript -var var.unittestSource -t changeDirTests.xsl -o %INST_TEMP_DIR%\unittests.wxs
+heat dir ..\PythonScript\python_tests -ag -cg CG_UnitTests -dr D_PythonScript -var var.unittestSource -t changeDirTests.xsl -o %INST_TEMP_DIR%\unittests.wxs -platform=%NAME_ADDON%
 if NOT [%ERRORLEVEL%]==[0] (
  goto error
 )
 
 echo Compiling Unit test WiX source
-candle %INST_TEMP_DIR%\unittests.wxs -o %INST_TEMP_DIR%\unittests.wixobj -dunittestSource=..\PythonScript\python_tests
+candle %INST_TEMP_DIR%\unittests.wxs -o %INST_TEMP_DIR%\unittests.wixobj -dunittestSource=..\PythonScript\python_tests -arch %MSI_ARCH%
 if NOT [%ERRORLEVEL%]==[0] (
  goto error
 )
 
 echo Generating WiX information for ..\docs\build\html
-heat dir ..\docs\build\html -ag -cg CG_HtmlDocs -dr D_PythonScript -var var.htmldocsSource -t changeDirHtmlDoc.xsl -o %INST_TEMP_DIR%\htmldoc.wxs
+heat dir ..\docs\build\html -ag -cg CG_HtmlDocs -dr D_PythonScript -var var.htmldocsSource -t changeDirHtmlDoc.xsl -o %INST_TEMP_DIR%\htmldoc.wxs -platform=%NAME_ADDON%
 if NOT [%ERRORLEVEL%]==[0] (
  goto error
 )
 
 echo Compiling Html doc WiX source
-candle %INST_TEMP_DIR%\htmldoc.wxs -o %INST_TEMP_DIR%\htmldoc.wixobj -dhtmldocsSource=..\docs\build\html
+candle %INST_TEMP_DIR%\htmldoc.wxs -o %INST_TEMP_DIR%\htmldoc.wixobj -dhtmldocsSource=..\docs\build\html -arch %MSI_ARCH%
 if NOT [%ERRORLEVEL%]==[0] (
  goto error
 )
 
 echo Compiling main PythonScript installer
-candle pythonscript.wxs -o %INST_TEMP_DIR%\pythonscript.wixobj -dversion=%PYTHONSCRIPTVERSION% -dbaseDir=.. -dpythonDir=%PYTHONBUILDDIR% -dvariantDir=%PYTHONSCRIPTDLLDIR%
+candle pythonscript.wxs -o %INST_TEMP_DIR%\pythonscript.wixobj -dversion=%PYTHONSCRIPTVERSION% -dbaseDir=.. -dpythonDir=%PYTHONBUILDDIR% -dvariantDir=%PYTHONSCRIPTDLLDIR% -dPlatform=%MSI_ARCH% -arch %MSI_ARCH%
 if NOT [%ERRORLEVEL%]==[0] (
  goto error
 )

--- a/installer/buildReleaseZips.bat
+++ b/installer/buildReleaseZips.bat
@@ -67,46 +67,48 @@ rd /s /q %INST_TEMP_DIR%\release
 echo Creating directories
 mkdir %INST_TEMP_DIR%\release\Full\plugins\PythonScript\lib
 mkdir %INST_TEMP_DIR%\release\Full\plugins\PythonScript\scripts
-mkdir %INST_TEMP_DIR%\release\Full\plugins\doc\PythonScript
+mkdir %INST_TEMP_DIR%\release\Full\plugins\PythonScript\doc
 mkdir %INST_TEMP_DIR%\release\Min\plugins\PythonScript\lib
 mkdir %INST_TEMP_DIR%\release\Min\plugins\PythonScript\scripts
-mkdir %INST_TEMP_DIR%\release\Min\plugins\doc\PythonScript
+mkdir %INST_TEMP_DIR%\release\Min\plugins\PythonScript\doc
 mkdir %INST_TEMP_DIR%\release\Extra\plugins\PythonScript\lib
 mkdir %INST_TEMP_DIR%\release\Tcl\plugins\PythonScript\lib
 
 echo Copying Python27.dll
-copy %PYTHONBUILDDIR%\python27.dll %INST_TEMP_DIR%\release\Full
-copy %PYTHONBUILDDIR%\python27.dll %INST_TEMP_DIR%\release\Min
+copy %PYTHONBUILDDIR%\python27.dll %INST_TEMP_DIR%\release\Full\plugins\PythonScript
+copy %PYTHONBUILDDIR%\python27.dll %INST_TEMP_DIR%\release\Min\plugins\PythonScript
 
 echo Copying PythonScript.dll
-copy ..\%PYTHONSCRIPTDLLDIR%\release\PythonScript.dll %INST_TEMP_DIR%\release\Full\plugins
-copy ..\%PYTHONSCRIPTDLLDIR%\release\PythonScript.dll %INST_TEMP_DIR%\release\min\plugins
+copy ..\%PYTHONSCRIPTDLLDIR%\release\PythonScript.dll %INST_TEMP_DIR%\release\Full\plugins\PythonScript
+copy ..\%PYTHONSCRIPTDLLDIR%\release\PythonScript.dll %INST_TEMP_DIR%\release\Min\plugins\PythonScript
 
 echo Copying Help
-xcopy /s /q ..\docs\build\html\*.* %INST_TEMP_DIR%\release\full\plugins\doc\PythonScript
-xcopy /s /q ..\docs\build\html\*.* %INST_TEMP_DIR%\release\min\plugins\doc\PythonScript
+xcopy /s /q ..\docs\build\html\*.* %INST_TEMP_DIR%\release\Full\plugins\PythonScript\doc
+xcopy /s /q ..\docs\build\html\*.* %INST_TEMP_DIR%\release\Min\plugins\PythonScript\doc
 
 echo Copying Scripts
-xcopy /s /q ..\scripts\*.* %INST_TEMP_DIR%\release\full\plugins\PythonScript\scripts
-copy ..\scripts\startup.py %INST_TEMP_DIR%\release\min\plugins\PythonScript\scripts
+xcopy /s /q ..\scripts\*.* %INST_TEMP_DIR%\release\Full\plugins\PythonScript\scripts
+copy ..\scripts\startup.py %INST_TEMP_DIR%\release\Min\plugins\PythonScript\scripts
 
 echo Copying Lib directories
-xcopy /s /q ..\PythonLib\full\*.* %INST_TEMP_DIR%\release\full\plugins\PythonScript\lib
-xcopy /s /q ..\PythonLib\full_dll%NAME_ADDON%\*.* %INST_TEMP_DIR%\release\full\plugins\PythonScript\lib
-xcopy /s /q ..\PythonLib\min\*.* %INST_TEMP_DIR%\release\min\plugins\PythonScript\lib
+xcopy /s /q ..\PythonLib\full\*.* %INST_TEMP_DIR%\release\Full\plugins\PythonScript\lib
+xcopy /s /q ..\PythonLib\full_dll%NAME_ADDON%\*.* %INST_TEMP_DIR%\release\Full\plugins\PythonScript\lib
+xcopy /s /q ..\PythonLib\min\*.* %INST_TEMP_DIR%\release\Min\plugins\PythonScript\lib
 
 echo Copying Extra lib directory
-xcopy /s /q ..\PythonLib\extra\*.* %INST_TEMP_DIR%\release\extra\plugins\pythonscript\lib
-xcopy /s /q ..\PythonLib\extra_dll%NAME_ADDON%\*.* %INST_TEMP_DIR%\release\extra\plugins\pythonscript\lib
+xcopy /s /q ..\PythonLib\extra\*.* %INST_TEMP_DIR%\release\Extra\plugins\pythonscript\lib
+xcopy /s /q ..\PythonLib\extra_dll%NAME_ADDON%\*.* %INST_TEMP_DIR%\release\Extra\plugins\pythonscript\lib
 
 echo Copying Tcl directory
 xcopy /s /q ..\PythonLib\tcl\*.* %INST_TEMP_DIR%\release\tcl\plugins\pythonscript\lib
 xcopy /s /q ..\PythonLib\tcl_dll%NAME_ADDON%\*.* %INST_TEMP_DIR%\release\tcl\plugins\pythonscript\lib
 
+mkdir %INSTALLERDIR%\build\%PYTHONSCRIPTVERSION%
 
+cd %INST_TEMP_DIR%\release\Full\plugins\PythonScript
+%SEVENZIPEXE% a -r -tzip %INSTALLERDIR%\build\%PYTHONSCRIPTVERSION%\PythonScript_Full_%PYTHONSCRIPTVERSION%%NAME_ADDON%_PluginAdmin.zip .
 
 cd %INST_TEMP_DIR%\release\Full
-mkdir %INSTALLERDIR%\build\%PYTHONSCRIPTVERSION%
 %SEVENZIPEXE% a -r -t7z %INSTALLERDIR%\build\%PYTHONSCRIPTVERSION%\PythonScript_Full_%PYTHONSCRIPTVERSION%%NAME_ADDON%.7z .
 %SEVENZIPEXE% a -r -tzip %INSTALLERDIR%\build\%PYTHONSCRIPTVERSION%\PythonScript_Full_%PYTHONSCRIPTVERSION%%NAME_ADDON%.zip .
 


### PR DESCRIPTION
- adapt zip structure to the changed plugin dir since N++ 7.6, but N++ 7.8 is needed to be able to load the python2.7 dll from plugin dir

- adapt local doc search path
- adapt msi + try to fix #118