### PR TITLE
add SCN_MARGINRIGHTCLICK returns

### DIFF
--- a/PythonScript/src/ScintillaWrapper.cpp
+++ b/PythonScript/src/ScintillaWrapper.cpp
@@ -175,6 +175,12 @@ void ScintillaWrapper::notify(SCNotification *notifyCode)
                 params["modifiers"] = notifyCode->modifiers;
    				break;
 
+			case SCN_MARGINRIGHTCLICK:
+				params["margin"] = notifyCode->margin;
+                params["position"] = notifyCode->position;
+                params["modifiers"] = notifyCode->modifiers;
+   				break;
+
 			case SCN_NEEDSHOWN:
                 params["position"] = notifyCode->position;
                 params["length"] = notifyCode->length;

--- a/docs/source/enums.rst
+++ b/docs/source/enums.rst
@@ -96,7 +96,11 @@ SCINTILLANOTIFICATION
 
 .. attribute:: SCINTILLANOTIFICATION.MARGINCLICK
 
-   Arguments contains: ``margin``
+   Arguments contains: ``modifiers``, ``position``, ``margin``
+
+.. attribute:: SCINTILLANOTIFICATION.MARGINRIGHTCLICK
+
+   Arguments contains: ``modifiers``, ``position``, ``margin``
 
 .. attribute:: SCINTILLANOTIFICATION.NEEDSHOWN
 


### PR DESCRIPTION
fix #250 .

Output of test script now with left-click and then right-click (with expected output):

```
{'code': 2010, 'idFrom': 0, 'hwndFrom': 9177554, 'margin': 2, 'position': 0, 'modifiers': 0}
{'code': 2031, 'idFrom': 0, 'hwndFrom': 9177554, 'margin': 2, 'position': 0, 'modifiers': 0}
```

(tested using the AppVeyor artifact : https://ci.appveyor.com/project/bruderstein/pythonscript/builds/45246939 "Release/64-bit")

Cheers.
