### PR TITLE
add missing SCNotification attributes 

### DIFF
--- a/PythonScript/src/ScintillaWrapper.cpp
+++ b/PythonScript/src/ScintillaWrapper.cpp
@@ -171,11 +171,6 @@ void ScintillaWrapper::notify(SCNotification *notifyCode)
 				break;
 
 			case SCN_MARGINCLICK:
-				params["margin"] = notifyCode->margin;
-                params["position"] = notifyCode->position;
-                params["modifiers"] = notifyCode->modifiers;
-   				break;
-
 			case SCN_MARGINRIGHTCLICK:
 				params["margin"] = notifyCode->margin;
                 params["position"] = notifyCode->position;
@@ -203,11 +198,6 @@ void ScintillaWrapper::notify(SCNotification *notifyCode)
 				break;
 
 			case SCN_DWELLSTART:
-				params["position"] = notifyCode->position;
-				params["x"] = notifyCode->x;
-				params["y"] = notifyCode->y;
-				break;
-
 			case SCN_DWELLEND:
 				params["position"] = notifyCode->position;
 				params["x"] = notifyCode->x;
@@ -263,6 +253,8 @@ void ScintillaWrapper::notify(SCNotification *notifyCode)
 			default:
 				// Unknown notification, so just fill in all the parameters.
 				params["position"] = notifyCode->position;
+				params["ch"] = notifyCode->ch;
+				params["modifiers"] = notifyCode->modifiers;
 				params["modificationType"] = notifyCode->modificationType;
 				if (notifyCode->text) 
 				{
@@ -272,18 +264,21 @@ void ScintillaWrapper::notify(SCNotification *notifyCode)
 				}
 				params["length"] = notifyCode->length;
 				params["linesAdded"] = notifyCode->linesAdded;
-				params["line"] = notifyCode->line;
-				params["foldLevelNow"] = notifyCode->foldLevelNow;
-				params["foldLevelPrev"] = notifyCode->foldLevelPrev;
-				params["annotationLinesAdded"] = notifyCode->annotationLinesAdded;
-				params["listType"] = notifyCode->listType;
 				params["message"] = notifyCode->message;
 				params["wParam"] = notifyCode->wParam;
 				params["lParam"] = notifyCode->lParam;
-				params["modifiers"] = notifyCode->modifiers;
-				params["token"] = notifyCode->token;
+				params["line"] = notifyCode->line;
+				params["foldLevelNow"] = notifyCode->foldLevelNow;
+				params["foldLevelPrev"] = notifyCode->foldLevelPrev;
+				params["margin"] = notifyCode->margin;
+				params["listType"] = notifyCode->listType;
 				params["x"] = notifyCode->x;
 				params["y"] = notifyCode->y;
+				params["token"] = notifyCode->token;
+				params["annotationLinesAdded"] = notifyCode->annotationLinesAdded;
+				params["updated"] = notifyCode->updated;
+				params["listCompletionMethod"] = notifyCode->listCompletionMethod;
+				params["characterSource"] = notifyCode->characterSource;
 				break;
 			}
 			

--- a/PythonScript/src/ScintillaWrapper.cpp
+++ b/PythonScript/src/ScintillaWrapper.cpp
@@ -106,6 +106,7 @@ void ScintillaWrapper::notify(SCNotification *notifyCode)
 
 			case SCN_CHARADDED:
 				params["ch"] = notifyCode->ch;
+				params["characterSource"] = notifyCode->characterSource;
 				break;
 
 			case SCN_SAVEPOINTREACHED:
@@ -190,9 +191,11 @@ void ScintillaWrapper::notify(SCNotification *notifyCode)
 				break;
 
 			case SCN_USERLISTSELECTION:
+				params["position"] = notifyCode->position;
+				params["ch"] = notifyCode->ch;
 				params["text"] = notifyCode->text;
 				params["listType"] = notifyCode->listType;
-                params["position"] = notifyCode->position;
+				params["listCompletionMethod"] = notifyCode->listCompletionMethod;
 				break;
 
 			case SCN_URIDROPPED:
@@ -232,8 +235,10 @@ void ScintillaWrapper::notify(SCNotification *notifyCode)
 				break;
 
 			case SCN_AUTOCSELECTION:
+				params["position"] = notifyCode->position;
+				params["ch"] = notifyCode->ch;
 				params["text"] = notifyCode->text;
-                params["position"] = notifyCode->position;
+				params["listCompletionMethod"] = notifyCode->listCompletionMethod;
 				break;
 
 			case SCN_AUTOCCANCELLED:
@@ -245,6 +250,15 @@ void ScintillaWrapper::notify(SCNotification *notifyCode)
 			case SCN_FOCUSIN:
 			case SCN_FOCUSOUT:
                 break;
+
+			case SCN_AUTOCCOMPLETED:
+				params["listCompletionMethod"] = notifyCode->listCompletionMethod;
+				break;
+
+			case SCN_AUTOCSELECTIONCHANGE:
+				params["position"] = notifyCode->position;
+				params["text"] = notifyCode->text;
+				params["listType"] = notifyCode->listType;
 
 			default:
 				// Unknown notification, so just fill in all the parameters.

--- a/docs/source/enums.rst
+++ b/docs/source/enums.rst
@@ -85,6 +85,8 @@ SCINTILLANOTIFICATION
 
 .. attribute:: SCINTILLANOTIFICATION.UPDATEUI
 
+   Arguments contains: ``updated``
+
 .. attribute:: SCINTILLANOTIFICATION.MODIFIED
 
    Arguments contains: ``position``, ``modificationType`` (a set of flags from :class:`MODIFICATIONFLAGS`), ``text``, ``length``, ``linesAdded``, ``line``, ``foldLevelNow``, ``foldLevelPrev``,
@@ -104,6 +106,8 @@ SCINTILLANOTIFICATION
 
 .. attribute:: SCINTILLANOTIFICATION.NEEDSHOWN
 
+   Arguments contains: ``position``, ``length``
+
 .. attribute:: SCINTILLANOTIFICATION.PAINTED
 
    Note: Because Scintilla events are processed by Python asynchronously, care must be taken if handling a callback for this event
@@ -114,6 +118,8 @@ SCINTILLANOTIFICATION
    Arguments contains: ``position``, ``ch``, ``text``, ``listType``, ``listCompletionMethod``
 
 .. attribute:: SCINTILLANOTIFICATION.URIDROPPED
+
+   Arguments contains: ``text``
 
 .. attribute:: SCINTILLANOTIFICATION.DWELLSTART
 
@@ -143,7 +149,11 @@ SCINTILLANOTIFICATION
 
 .. attribute:: SCINTILLANOTIFICATION.INDICATORCLICK
 
+   Arguments contains: ``position``, ``modifiers``
+
 .. attribute:: SCINTILLANOTIFICATION.INDICATORRELEASE
+
+   Arguments contains: ``position``, ``modifiers``
 
 .. attribute:: SCINTILLANOTIFICATION.AUTOCCANCELLED
 

--- a/docs/source/enums.rst
+++ b/docs/source/enums.rst
@@ -159,7 +159,7 @@ SCINTILLANOTIFICATION
 
 .. attribute:: SCINTILLANOTIFICATION.AUTOCSELECTIONCHANGE
 
-   Arguments contains: ``position``, ``text``, ``listTyp``
+   Arguments contains: ``position``, ``text``, ``listType``
 
 SCINTILLAMESSAGE
 ----------------

--- a/docs/source/enums.rst
+++ b/docs/source/enums.rst
@@ -59,15 +59,15 @@ STATUSBARSECTION
 
 SCINTILLANOTIFICATION
 ---------------------
-.. _SCINTILLANOTFICATION:
-.. class:: SCINTILLANOTFICATION
+.. _SCINTILLANOTIFICATION:
+.. class:: SCINTILLANOTIFICATION
 .. attribute:: SCINTILLANOTIFICATION.STYLENEEDED
 
    Arguments contains: ``position``
 
 .. attribute:: SCINTILLANOTIFICATION.CHARADDED
 
-   Arguments contains: ``ch`` - the character added (as an int)
+   Arguments contains: ``ch`` - the character added (as an int), ``characterSource``
 
 .. attribute:: SCINTILLANOTIFICATION.SAVEPOINTREACHED
 
@@ -111,7 +111,7 @@ SCINTILLANOTIFICATION
 
 .. attribute:: SCINTILLANOTIFICATION.USERLISTSELECTION
 
-   Arguments contains: ``text``, ``listType``, ``position``
+   Arguments contains: ``position``, ``ch``, ``text``, ``listType``, ``listCompletionMethod``
 
 .. attribute:: SCINTILLANOTIFICATION.URIDROPPED
 
@@ -139,7 +139,7 @@ SCINTILLANOTIFICATION
 
 .. attribute:: SCINTILLANOTIFICATION.AUTOCSELECTION
 
-   Arguments contains: ``text``, ``position``
+   Arguments contains: ``position``, ``ch``, ``text``, ``listCompletionMethod``
 
 .. attribute:: SCINTILLANOTIFICATION.INDICATORCLICK
 
@@ -153,6 +153,13 @@ SCINTILLANOTIFICATION
 
 .. attribute:: SCINTILLANOTIFICATION.FOCUSOUT
 
+.. attribute:: SCINTILLANOTIFICATION.AUTOCOMPLETED
+
+   Arguments contains: ``listCompletionMethod``
+
+.. attribute:: SCINTILLANOTIFICATION.AUTOCSELECTIONCHANGE
+
+   Arguments contains: ``position``, ``text``, ``listTyp``
 
 SCINTILLAMESSAGE
 ----------------


### PR DESCRIPTION
Fix #253

(and fix spelling error "SCINTILLANOTFICATION" in documentation)

@chcg Before merging this, I'd like some clarification on the `params["text"]` return.  In some instances it is:

```C++
    case SCN_MODIFIED:
        ...
        if (notifyCode->text)
        {
            // notifyCode->text is not null terminated
            std::string text(notifyCode->text, notifyCode->length);
            params["text"] = text.c_str();
        }
        else
        {
            params["text"] = "";
        }
```

and in others, it is just:

```C++
    case SCN_URIDROPPED:
        params["text"] = notifyCode->text;
        break;
```

Assuming they should all be the same?

Some testing reveals that the simple seems to work:

```Python
from Npp import editor, SCINTILLANOTIFICATION

def _on_autoc(args):
    print(args)

editor.callbackSync(_on_autoc, [SCINTILLANOTIFICATION.AUTOCSELECTION])
```

and output:

```
{'code': 2022, 'idFrom': 0, 'hwndFrom': 6292298, 'position': 0, 'ch': 0, 'text': 'lorem', 'listCompletionMethod': 3}
{'code': 2022, 'idFrom': 0, 'hwndFrom': 6292298, 'position': 0, 'ch': 0, 'text': 'Get-NetAdapterEncapsulatedPacketTaskOffload', 'listCompletionMethod': 3}
```

I can convert them all like the first converting to `std::string` and `text.c_str()` if that is safer?  If so, I'll fix the existing and and the new ones I added in this PR with another commit to this PR before merging.

Cheers.
