### PR TITLE
Use Alpha for colors in ELEMENTCOLOUR APIs

### DIFF
--- a/PythonLib/full/ctypes/wintypes.py
+++ b/PythonLib/full/ctypes/wintypes.py
@@ -125,6 +125,9 @@ tagSIZE = SIZEL = SIZE
 def RGB(red, green, blue):
     return red + (green << 8) + (blue << 16)
 
+def RGBA(red, green, blue, alpha):
+    return red + (green << 8) + (blue << 16) + (alpha << 24)
+
 class FILETIME(ctypes.Structure):
     _fields_ = [("dwLowDateTime", DWORD),
                 ("dwHighDateTime", DWORD)]

--- a/PythonScript/src/ScintillaWrapper.h
+++ b/PythonScript/src/ScintillaWrapper.h
@@ -22,11 +22,15 @@
 
 struct SCNotification;
 
-#define COLOUR_RED(x)    (x & 0x0000FF)
-#define COLOUR_GREEN(x)  ((x & 0x00FF00) >> 8)
-#define COLOUR_BLUE(x)   ((x & 0xFF0000) >> 16)
+#define COLOUR_RED(x)     (x & 0x000000FF)
+#define COLOUR_GREEN(x)  ((x & 0x0000FF00) >> 8)
+#define COLOUR_BLUE(x)   ((x & 0x00FF0000) >> 16)
+#define COLOUR_ALPHA(x)  ((x & 0xFF000000) >> 24)
 
-#define MAKECOLOUR(x)    RGB(boost::python::extract<int>(x[0]),boost::python::extract<int>(x[1]),boost::python::extract<int>(x[2]))
+#define RGBA(r,g,b,a)    ( r + (g << 8) + (b << 16) + (a << 24) )
+
+#define MAKECOLOUR(x)       RGB(boost::python::extract<int>(x[0]),boost::python::extract<int>(x[1]),boost::python::extract<int>(x[2]))
+#define MAKEALPHACOLOUR(x) RGBA(boost::python::extract<int>(x[0]),boost::python::extract<int>(x[1]),boost::python::extract<int>(x[2]),boost::python::extract<int>(x[3]))
 
 struct out_of_bounds_exception : public std::exception
 {

--- a/PythonScript/src/ScintillaWrapperGenerated.cpp
+++ b/PythonScript/src/ScintillaWrapperGenerated.cpp
@@ -1116,8 +1116,8 @@ boost::python::str ScintillaWrapper::StyleGetInvisibleRepresentation(int style)
 void ScintillaWrapper::SetElementColour(int element, boost::python::tuple colourElement)
 {
 	DEBUG_TRACE(L"ScintillaWrapper::SetElementColour\n");
-	COLORREF rgbcolourElement = MAKECOLOUR(colourElement);
-	callScintilla(SCI_SETELEMENTCOLOUR, element, static_cast<LPARAM>(rgbcolourElement));
+	int rgbacolourElement = MAKEALPHACOLOUR(colourElement);
+	callScintilla(SCI_SETELEMENTCOLOUR, element, static_cast<LPARAM>(rgbacolourElement));
 }
 
 /** Get the colour of an element.
@@ -1126,7 +1126,7 @@ boost::python::tuple ScintillaWrapper::GetElementColour(int element)
 {
 	DEBUG_TRACE(L"ScintillaWrapper::GetElementColour\n");
 	int retVal = (int)callScintilla(SCI_GETELEMENTCOLOUR, element);
-	return boost::python::make_tuple(COLOUR_RED(retVal), COLOUR_GREEN(retVal), COLOUR_BLUE(retVal));
+	return boost::python::make_tuple(COLOUR_RED(retVal), COLOUR_GREEN(retVal), COLOUR_BLUE(retVal), COLOUR_ALPHA(retVal));
 }
 
 /** Use the default or platform-defined colour for an element.


### PR DESCRIPTION
Fix #276

Requires a 4-arg tuple for colorAlpha values for [`SCI_S/GETELEMENTCOLOUR`](https://www.scintilla.org/ScintillaDoc.html#SCI_SETELEMENTCOLOUR) APIs:

```
>>> editor.getElementColour(ELEMENT.HIDDEN_LINE)
(0, 0, 0, 0)
>>> editor.setElementColour(ELEMENT.HIDDEN_LINE, (255, 192, 192, 128) )
>>> editor.getElementColour(ELEMENT.HIDDEN_LINE)
(255, 192, 192, 128)
```

tuple is ( R, G, B, A), where 'A' is the alpha value (255 = opaque, 0 = transparent).

**NOTE:** Perhaps a nicer way to do this would be to have the macro assume a default alpha of 255, something like:

`RGBA(R, G, B, A=255)`

but I'm not sure how to do that?   Something like:

```
#include <stdio.h>

#define _ARG2(_0, _1, _2, _3, _4, ...) _4
#define NARG2(...) _ARG2(__VA_ARGS__, 4, 3, 2, 1, 0)

#define _THREE_OR_FOUR_3(NAME, r, g, b) r, g, b, NAME ## _default_arg_4()
#define _THREE_OR_FOUR_4(NAME, r, g, b, a) r, g, b, a

#define __THREE_OR_FOUR(NAME, N, ...) _THREE_OR_FOUR_ ## N (NAME, __VA_ARGS__)
#define _THREE_OR_FOUR(NAME, N, ...) __THREE_OR_FOUR(NAME, N, __VA_ARGS__)

#define THREE_OR_FOUR(NAME, ...) NAME(_THREE_OR_FOUR(NAME, NARG2(__VA_ARGS__), __VA_ARGS__))

#define RGBA(...) THREE_OR_FOUR(RGBA, __VA_ARGS__)
 
// function definition, also calls the macro, but you wouldn't notice
void RGBA(int r, int g, int b, int a) { printf("%s seeing r=%d, g=%d, b=%d, a=%d\n", __func__, r, g, b, a); }
 
static inline int RGBA_default_arg_4(void) {  return 255; }
 
int main (void) {
  // call expect default argument
  RGBA(1, 2, 3);
  // call with all
  RGBA(1, 2, 3, 128);
}
```
