### PR TITLE
handle endpos=0 for research and rereplace methods

### DIFF
--- a/PythonScript/src/ScintillaWrapper.cpp
+++ b/PythonScript/src/ScintillaWrapper.cpp
@@ -826,7 +826,7 @@ void ScintillaWrapper::replaceImpl(boost::python::object searchStr, boost::pytho
 		startPosition = 0;
 	}
 
-	if (endPosition > 0 && endPosition < length)
+	if (endPosition >= 0 && endPosition < length)
 	{
 		length = endPosition;
 	}
@@ -968,7 +968,7 @@ void ScintillaWrapper::searchImpl(boost::python::object searchStr,
 		startPosition = 0;
 	}
 
-	if (endPosition > 0 && endPosition < length)
+	if (endPosition >= 0 && endPosition < length)
 	{
 		length = endPosition;
 	}


### PR DESCRIPTION
For debug builds, this causes an assertion error due to the assert check in ansiiterator.h and utf8iterator.h.
I don't understand the reason for this, because for production builds there is an explicit _pos = _end call.
The changes look good to me and the tests show no problems. Any thoughts?

closes #248
