### PR TITLE
Add ESC key in console sets focus to current Scintilla editor buffer

### DIFF
--- a/PythonScript/src/ConsoleDialog.cpp
+++ b/PythonScript/src/ConsoleDialog.cpp
@@ -208,6 +208,11 @@ INT_PTR CALLBACK ConsoleDialog::run_dlgProc(UINT message, WPARAM wParam, LPARAM 
 				//MessageBox(NULL, _T("Command") , _T("Python Command"), 0);
 				return FALSE;
 			}
+            else if (LOWORD(wParam) == IDCANCEL)
+            {
+                ::SetFocus(getCurrScintilla());
+				return FALSE;
+			}
 			break;
 
 		case WM_SETFOCUS:

--- a/PythonScript/src/PythonScript.cpp
+++ b/PythonScript/src/PythonScript.cpp
@@ -718,3 +718,10 @@ static void previousScript()
 	runScript(g_previousScript.c_str(), false);
 	previousScript_clicked = false;
 }
+
+HWND getCurrScintilla()
+{
+    int which = -1;
+    ::SendMessage( nppData._nppHandle, NPPM_GETCURRENTSCINTILLA, 0, ( LPARAM )&which );
+    return ( which == 0 ) ? nppData._scintillaMainHandle : nppData._scintillaSecondHandle;
+}

--- a/PythonScript/src/PythonScript.h
+++ b/PythonScript/src/PythonScript.h
@@ -10,4 +10,8 @@
 // The first scintilla notification - this is 2000
 #define SCN_FIRST_NOTIFICATION   SCN_STYLENEEDED
 
+#include <windows.h>
+
+HWND getCurrScintilla();
+
 #endif


### PR DESCRIPTION
Fix #290