### PR TITLE
Change input box get focus after run command

### DIFF
--- a/PythonScript/src/ConsoleDialog.h
+++ b/PythonScript/src/ConsoleDialog.h
@@ -37,7 +37,7 @@ public:
 	std::string getContinuePrompt();
 	HWND getScintillaHwnd() { return m_scintilla; }
 
-	void giveInputFocus() { SetFocus(m_hInput); }
+	void giveInputFocus() { SetFocus(m_hCombo); }
 
 	void runEnabled(bool enabled);
 


### PR DESCRIPTION
Currently, after running a command, the focus goes to the output window with the cursor blinking in it.  One needs press `Tab` twice to return to the input combobox to enter a subsequent command.  It seems to be stemming from a `SetFocus()` command to the handle of `m_hInput` which is defined:

PythonScript/PythonScript/src/ConsoleDialog.cpp:
```
126:      m_hInput = FindWindowEx(m_hCombo, NULL, L"Edit", NULL);
```

Though I'm not sure what that returns since I don't see an Edit box in the PythonScript dockable dialog.  There is however a combobox which is set to `m_hCombo` and that is where the commands are entered.

This changes the `giveInputFocus()` method in ConsoleDialog class to give focus to the combobox.  The only "issue" is that when gaining focus, the text in the combobox is not cleared, it is highlighted.  One can simply start typing and it will overwrite.  I think a vast improvement.

Fix #184
