### PR TITLE
Ensure file activation works reliably

### DIFF
--- a/PythonScript/python_tests/tests/test_NotepadWrapperTestCase.py
+++ b/PythonScript/python_tests/tests/test_NotepadWrapperTestCase.py
@@ -1628,6 +1628,28 @@ class NotepadTestCase(unittest.TestCase):
         ''' '''
         self.__test_invalid_parameter_passed(notepad.isAutoIndention)
 
+    def test_activateFile(self):
+        # Create and open two files
+        file1 = self.get_temp_filename()
+        file2 = self.get_temp_filename()
+        self.assertTrue(notepad.open(file1))
+        self.assertTrue(notepad.open(file2))
+
+        # open two temp files
+        notepad.new()
+        temp_1 = notepad.getCurrentFilename()
+        notepad.new()
+        temp_2 = notepad.getCurrentFilename()
+
+        self.assertTrue(notepad.activateFile(file1))
+        notepad.close()
+        self.assertTrue(notepad.activateFile(temp_1))
+        notepad.close()
+        self.assertTrue(notepad.activateFile(file2))
+        notepad.close()
+        self.assertTrue(notepad.activateFile(temp_2))
+        notepad.close()
+
 
 suite = unittest.TestLoader().loadTestsFromTestCase(NotepadTestCase)
 

--- a/PythonScript/src/NotepadPlusWrapper.cpp
+++ b/PythonScript/src/NotepadPlusWrapper.cpp
@@ -441,7 +441,14 @@ bool NotepadPlusWrapper::activateFileString(boost::python::str filename)
 {
 	notAllowedInScintillaCallback("activateFile() cannot be called in a synchronous editor callback. "
 		"Use an asynchronous callback, or avoid using activateFile() in the callback handler");
-	return handleFileNameToLongPath(NPPM_SWITCHTOFILE, filename);
+	bool res = handleFileNameToLongPath(NPPM_SWITCHTOFILE, filename);
+
+	if (!res) {
+		// issue 105
+		std::shared_ptr<TCHAR> tfileName = WcharMbcsConverter::char2tchar(boost::python::extract<const char*>(filename));
+		return static_cast<bool>(callNotepad(NPPM_SWITCHTOFILE, 0, reinterpret_cast<LPARAM>(tfileName.get())));
+	}
+	return res;
 }
 
 bool NotepadPlusWrapper::reloadFile(boost::python::str filename, bool alert)


### PR DESCRIPTION
Fixes issue #105 to ensure file activation works reliably, even when the long path handling fails.