### PR TITLE
Handling of invalid values in the Search, Search, Replace and Replace methods

### DIFF
--- a/PythonScript/python_tests/tests/test_SearchReplaceInvalidArgumentTestCase.py
+++ b/PythonScript/python_tests/tests/test_SearchReplaceInvalidArgumentTestCase.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+import unittest
+from Npp import notepad, editor
+
+class SearchReplaceInvalidArgumentTestCase(unittest.TestCase):
+    def setUp(self):
+        notepad.new()
+
+    def tearDown(self):
+        notepad.close()
+
+    def test_invalid_search_argument(self):
+        for invalid_arg in ["", None]:
+            for method in [editor.research, editor.search, editor.replace, editor.rereplace]:
+                self.assertRaises(TypeError, method, invalid_arg, None)
+
+    def test_invalid_replace_argument(self):
+        for method in [editor.replace, editor.rereplace]:
+            self.assertRaises(TypeError, method, "abc", None)
+
+
+suite = unittest.TestLoader().loadTestsFromTestCase(SearchReplaceInvalidArgumentTestCase)

--- a/PythonScript/src/ScintillaWrapper.cpp
+++ b/PythonScript/src/ScintillaWrapper.cpp
@@ -808,6 +808,15 @@ void ScintillaWrapper::replaceImpl(boost::python::object searchStr, boost::pytho
 	intptr_t currentDocumentCodePage = this->GetCodePage();
 
 	std::string searchChars = extractEncodedString(searchStr, currentDocumentCodePage);
+
+	if (searchStr.is_none() || searchChars.empty()) {
+		throw NppPythonScript::ArgumentException("search parameter must not be none or an empty string");
+	}
+
+	if (replaceStr.is_none()) {
+		throw NppPythonScript::ArgumentException("repalce parameter must not be none");
+	}
+
 	std::string replaceChars;
 	bool isPythonReplaceFunction = true;
 
@@ -952,6 +961,11 @@ void ScintillaWrapper::searchImpl(boost::python::object searchStr,
 	intptr_t currentDocumentCodePage = this->GetCodePage();
 
 	std::string searchChars = extractEncodedString(searchStr, currentDocumentCodePage);
+
+	if (searchStr.is_none() || searchChars.empty())
+	{
+		throw NppPythonScript::ArgumentException("search parameter must not be none or an empty string");
+	}
 
 	if (!PyCallable_Check(matchFunction.ptr()))
 	{

--- a/PythonScript/src/ScintillaWrapper.cpp
+++ b/PythonScript/src/ScintillaWrapper.cpp
@@ -814,7 +814,7 @@ void ScintillaWrapper::replaceImpl(boost::python::object searchStr, boost::pytho
 	}
 
 	if (replaceStr.is_none()) {
-		throw NppPythonScript::ArgumentException("repalce parameter must not be none");
+		throw NppPythonScript::ArgumentException("replace parameter must not be none");
 	}
 
 	std::string replaceChars;

--- a/docs/source/scintilla.rst
+++ b/docs/source/scintilla.rst
@@ -5197,6 +5197,9 @@ Helper Methods
    See :meth:`editor.rereplace`, as this method is identical, with the exception that the search string is treated literally,
    and not as a regular expression.
 
+   The search argument triggers an exception if either an empty string or None is specified.
+   The replace argument triggers an exception if None is specified.
+
    If you use a function as the replace argument, the function will still receive a ``re.MatchObject`` like object as the parameter,
    ``group(0)`` will therefore always contain the string searched for (possibly in a different case if ``re.IGNORECASE`` was passed in the flags)
 
@@ -5233,6 +5236,8 @@ Helper Methods
    The replace function provided to editor.rereplace should not invoke additional calls to editor.rereplace or other replacement functions
    that modify the same text being processed. Doing so may result in unpredictable behavior.
 
+   The search argument triggers an exception if either an empty string or None is specified.
+   The replace argument triggers an exception if None is specified.
 
    ``flags`` are from the re module (e.g. ``re.IGNORECASE``), so ``import re`` if you use the flags.
 


### PR DESCRIPTION
fixes #172

Additional methods such as `editor.replaceSel` must be handled differently, as these are automatically generated by the iface file.